### PR TITLE
allow passing private key through config option `serviceAccountPrivateKey`

### DIFF
--- a/lib/gitkitclient.js
+++ b/lib/gitkitclient.js
@@ -40,7 +40,7 @@ function GitkitClient(options) {
   this.authClient = new google.auth.JWT(
       options.serviceAccountEmail,
       options.serviceAccountPrivateKeyFile,
-      undefined,
+      options.serviceAccountPrivateKey,
       [GitkitClient.GITKIT_SCOPE],
       '');
   this.certificateCache = null;


### PR DESCRIPTION
This allows consumers to not store a private key file on their application hosts.