### PR TITLE
Update getGitkitCerts_ method

### DIFF
--- a/lib/gitkitclient.js
+++ b/lib/gitkitclient.js
@@ -365,25 +365,25 @@ GitkitClient.prototype.getGitkitCerts_ = function(callback) {
  * @private
  */
 GitkitClient.prototype.cacheCerts_ = function(body, res, callback) {
- var self = this;
- var cacheControl = res.headers['cache-control'];
- var cacheAge = -1;
- if (cacheControl) {
-   var pattern = new RegExp('max-age=([0-9]*)');
-   var regexResult = pattern.exec(cacheControl);
-   if (regexResult.length === 2) {
-     // Cache results with max-age (in seconds)
-     cacheAge = regexResult[1] * 1000; // milliseconds
-   }
- }
+  var self = this;
+  var cacheControl = res.headers['cache-control'];
+  var cacheAge = -1;
+  if (cacheControl) {
+    var pattern = new RegExp('max-age=([0-9]*)');
+    var regexResult = pattern.exec(cacheControl);
+    if (regexResult.length === 2) {
+      // Cache results with max-age (in seconds)
+      cacheAge = regexResult[1] * 1000; // milliseconds
+    }
+  }
 
- var now = new Date();
- self.certificateExpiry = cacheAge === -1 ? null : new Date(now.getTime() + cacheAge);
- try {
-   body = JSON.parse(body);
- } catch (err) { /* no op */ }
- self.certificateCache = body;
- callback(null, body);
+  var now = new Date();
+  self.certificateExpiry = cacheAge === -1 ? null : new Date(now.getTime() + cacheAge);
+  try {
+    body = JSON.parse(body);
+  } catch (err) { /* no op */ }
+  self.certificateCache = body;
+  callback(null, body);
 };
 
 /**


### PR DESCRIPTION
If server API key is configured, use it to fetch Gitkit public keys. Otherwise, use service account to get public keys.