### PR TITLE
Update getGitkitCerts_ method

### DIFF
--- a/lib/gitkitclient.js
+++ b/lib/gitkitclient.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+var request = require('request');
 var google = require('googleapis');
 var async = require('async');
 var gitkit = google.identitytoolkit('v3');
@@ -43,6 +44,7 @@ function GitkitClient(options) {
       options.serviceAccountPrivateKey,
       [GitkitClient.GITKIT_SCOPE],
       '');
+  this.serverApiKey = options.serverApiKey;
   this.certificateCache = null;
   this.certificateExpiry = null;
 }
@@ -319,38 +321,67 @@ GitkitClient.prototype.getGitkitCerts_ = function(callback) {
   }
 
   var self = this;
-  this.authClient.authorize(function(err, tokens) {
-    if (err) {
-      console.log(err);
-      callback(err, null);
-    }
-    self.authClient.request({
-      method: 'GET',
-      uri: GitkitClient.GITKIT_CERT_URL,
-      json: true
-    }, function(err, body, res) {
+  var error;
+  if (this.serverApiKey) {
+    request({
+      url: GitkitClient.GITKIT_CERT_URL,
+      qs: {'key' : this.serverApiKey},
+      method: 'GET'
+    }, function(err, res, body) {
+      body = JSON.parse(body);
+      if (err || body['error']) {
+        callback('Invalid server API key' , null);
+      } else {        
+        self.cacheCerts_(body, res, callback);
+      }
+    });
+  } else {
+    this.authClient.authorize(function(err, tokens) {
       if (err) {
-        callback('Failed to retrieve verification certificates: ' + err, null);
+        console.log(err);
+        callback(err, null);
         return;
       }
-
-      var cacheControl = res.headers['cache-control'];
-      var cacheAge = -1;
-      if (cacheControl) {
-        var pattern = new RegExp('max-age=([0-9]*)');
-        var regexResult = pattern.exec(cacheControl);
-        if (regexResult.length === 2) {
-          // Cache results with max-age (in seconds)
-          cacheAge = regexResult[1] * 1000; // milliseconds
+      self.authClient.request({
+        method: 'GET',
+        uri: GitkitClient.GITKIT_CERT_URL,
+        json: true
+      }, function(err, body, res) {
+        if (err || body['error']) {
+          callback('Invalid service account' , null);
+        } else {
+          self.cacheCerts_(body, res, callback);
         }
-      }
-
-      var now = new Date();
-      self.certificateExpiry = cacheAge === -1 ? null : new Date(now.getTime() + cacheAge);
-      self.certificateCache = body;
-      callback(null, body);
+      });
     });
-  });
+  }
+};
+
+/**
+ * Store certs in cache.
+ *
+ * @param {Object} body The body of request
+ * @param {Object} res The response of request
+ * @param {function} callback Callback supplying the certificates
+ * @private
+ */
+GitkitClient.prototype.cacheCerts_ = function(body, res, callback) {
+  var self = this;
+  var cacheControl = res.headers['cache-control'];
+  var cacheAge = -1;
+  if (cacheControl) {
+    var pattern = new RegExp('max-age=([0-9]*)');
+    var regexResult = pattern.exec(cacheControl);
+    if (regexResult.length === 2) {
+      // Cache results with max-age (in seconds)
+      cacheAge = regexResult[1] * 1000; // milliseconds
+    }
+  }
+
+  var now = new Date();
+  self.certificateExpiry = cacheAge === -1 ? null : new Date(now.getTime() + cacheAge);
+  self.certificateCache = body;
+  callback(null, body);
 };
 
 /**


### PR DESCRIPTION
If server API key is configured, use it to fetch Gitkit public keys. Otherwise, use service account to get keys.